### PR TITLE
is_running conflicts with pyopendial

### DIFF
--- a/retico_core/abstract.py
+++ b/retico_core/abstract.py
@@ -451,7 +451,7 @@ class AbstractModule:
                 auxiliary information.
         """
         self._right_buffers = []
-        self.is_running = False
+        self._is_running = False
         self._previous_iu = None
         self._left_buffers = []
         self.mutex = threading.Lock()
@@ -520,7 +520,7 @@ class AbstractModule:
         """
         if not left_buffer or not isinstance(left_buffer, IncrementalQueue):
             return
-        if self.is_running:
+        if self._is_running:
             self.stop()
         self._left_buffers.append(left_buffer)
 
@@ -533,7 +533,7 @@ class AbstractModule:
             left_buffer (IncrementalQueue): The left buffer to remove from the
                 module.
         """
-        if self.is_running:
+        if self._is_running:
             self.stop()
         self._left_buffers.remove(left_buffer)
 
@@ -556,7 +556,7 @@ class AbstractModule:
         """
         if not right_buffer or not isinstance(right_buffer, IncrementalQueue):
             return
-        if self.is_running:
+        if self._is_running:
             self.stop()
         self._right_buffers.append(right_buffer)
 
@@ -569,7 +569,7 @@ class AbstractModule:
             right_buffer (IncrementalQueue): The right buffer to remove from the
                 module.
         """
-        if self.is_running:
+        if self._is_running:
             self.stop()
         self._right_buffers.remove(right_buffer)
 
@@ -636,7 +636,7 @@ class AbstractModule:
         Args:
             module: A module that is subscribed to this module
         """
-        if self.is_running:
+        if self._is_running:
             self.stop()
         # We get a copy of the buffers because we are mutating it
         rbs = self.right_buffers()
@@ -655,7 +655,7 @@ class AbstractModule:
         Args:
             module: A module that this module is subscribed to
         """
-        if self.is_running:
+        if self._is_running:
             self.stop()
         # We get a copy of the buffers because we are mutating it
         lbs = self.left_buffers()
@@ -672,7 +672,7 @@ class AbstractModule:
 
         This method stops the execution of the module.
         """
-        if self.is_running:
+        if self._is_running:
             self.stop()
         lbs = self.left_buffers()
         rbs = self.right_buffers()
@@ -706,8 +706,8 @@ class AbstractModule:
 
     def _run(self):
         self.prepare_run()
-        self.is_running = True
-        while self.is_running:
+        self._is_running = True
+        while self._is_running:
             for buffer in self._left_buffers:
                 with self.mutex:
                     try:
@@ -803,7 +803,7 @@ class AbstractModule:
         """Stops the execution of the processing pipeline of this module at the
         next possible point in time. This may be after the next incoming IU is
         processed."""
-        self.is_running = False
+        self._is_running = False
         if clear_buffer:
             for buffer in self.right_buffers():
                 while not buffer.empty():
@@ -928,8 +928,8 @@ class AbstractProducingModule(AbstractModule):
 
     def _run(self):
         self.prepare_run()
-        self.is_running = True
-        while self.is_running:
+        self._is_running = True
+        while self._is_running:
             with self.mutex:
                 output_message = self.process_update(None)
                 if output_message:
@@ -999,8 +999,8 @@ class AbstractTriggerModule(AbstractProducingModule):
 
     def _run(self):
         self.prepare_run()
-        self.is_running = True
-        while self.is_running:
+        self._is_running = True
+        while self._is_running:
             with self.mutex:
                 time.sleep(0.05)
         self.shutdown()

--- a/retico_core/debug.py
+++ b/retico_core/debug.py
@@ -25,14 +25,22 @@ class DebugModule(abstract.AbstractConsumingModule):
     def input_ius():
         return [abstract.IncrementalUnit]
 
+    def __init__(self, print_payload_only=False):
+        super().__init__()
+        self.print_payload_only = print_payload_only
+
     def process_update(self, update_message):
-        print(f"Debug: Update Message ({len(update_message)})")
-        for i, (iu, ut) in enumerate(update_message):
-            print(f"{i}: {iu} (UpdateType: {ut})")
-            print("  PreviousIU:", iu.previous_iu)
-            print("  GroundedInIU:", iu.grounded_in)
-            print("  Age:", iu.age())
-        print(f"End of Debug Message")
+        if self.print_payload_only:
+            for iu, ut in update_message:
+                print(ut, iu.payload)
+        else:
+            print(f"Debug: Update Message ({len(update_message)})")
+            for i, (iu, ut) in enumerate(update_message):
+                print(f"{i}: {iu} (UpdateType: {ut})")
+                print("  PreviousIU:", iu.previous_iu)
+                print("  GroundedInIU:", iu.grounded_in)
+                print("  Age:", iu.age())
+            print(f"End of Debug Message")
 
 
 class CallbackModule(abstract.AbstractConsumingModule):


### PR DESCRIPTION
I changed all instances in abstract.py of `is_running` to `_is_running` because it conflicted with module code in pyOpenDial. The pyOpenDial DM module has to inherit from retico's AbstractModule and pyOpenDial's Module, causing the conflict. The variable is internal to AbstractModule so it shouldn't cause any issues. I tested the change locally and it seems to be okay. 