### PR TITLE
Update abstract.py

### DIFF
--- a/retico_core/abstract.py
+++ b/retico_core/abstract.py
@@ -739,6 +739,8 @@ class AbstractModule:
         self.prepare_run()
         self._is_running = True
         while self._is_running:
+            # When buffer is empty the loop is too tight and chokes the entire system. (Loop executes without releasing resources to the OS)
+            time.sleep(0.00001)
             for buffer in self._left_buffers:
                 with self.mutex:
                     try:


### PR DESCRIPTION
There was a tight loop in the AbstractModule, if the buffer was empty the loop would essentially iterate as an empty and infinite loop and would not release resources to the OS. This was an intermittent issue that would result in significant slowdowns system-wide and my program would run so slowly it was impossible to use. It started showing up once I started passing more data between client/server using ZMQ.
